### PR TITLE
security: audit hardening — zeroize secrets, strip logs, sync docs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -194,7 +194,7 @@ The frontend only receives sanitized views (`MessageView`, `IdentityInfo`) via T
 
 **Strict in-order delivery.** The ratchet counter must match `recv_count` exactly. Out-of-order or dropped messages cause decryption failure and session state divergence. No message skipping/buffering is implemented.
 
-**Log file.** Logging is disabled in release builds. In debug builds, logs are sent to stdout only (no file target), reducing forensic artifacts on disk.
+**Log file.** Logging is fully disabled in release builds — `tauri-plugin-log` is not registered and all `log::` macro call sites are compiled out via `#[cfg(debug_assertions)]`, eliminating both output and string literals from the release binary. In debug builds, logs are sent to stdout only (no file target).
 
 **Router cache forensics.** `i2p_router_cache.bin` is observable on disk. It contains only public I2P infrastructure router infos (no user identity, no destinations, no messages), but its presence confirms I2P usage.
 
@@ -202,6 +202,6 @@ The frontend only receives sanitized views (`MessageView`, `IdentityInfo`) via T
 
 **Cold boot.** Message content in RAM is vulnerable if the device is physically compromised during an active session before TTL fires or panic wipe is triggered. `mlock` mitigates swap risk on Unix; Windows has no equivalent guarantee.
 
-**No peer identity pinning.** The `ech0://` link contains the peer's public keys, but there is no certificate or long-term identity to pin across sessions. If an attacker intercepts the link before the peer receives it, they could substitute their own keys. The security model assumes the link is transmitted over a pre-existing trusted channel (e.g., Signal, in-person).
+**Safety numbers (v1).** A session fingerprint derived from `SHA256(IK_pub_a || IK_pub_b)` (sorted canonically) is displayed in the UI as 5 groups of 5 digits. Both peers can compare this value out-of-band to confirm no MITM key substitution occurred. However, there is no long-term identity to pin across sessions — the security model assumes the `ech0://` link is transmitted over a pre-existing trusted channel (e.g., Signal, in-person).
 
-**CSP disabled.** `tauri.conf.json` sets `"csp": null`. For a local-only WebView loading from Tauri's asset server this is low-risk, but enabling a strict CSP is recommended for production.
+**CSP.** `tauri.conf.json` enforces a strict Content Security Policy: `default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: asset: https://asset.localhost; connect-src ipc: http://ipc.localhost`. The `'unsafe-inline'` for styles is required by Tailwind CSS runtime utilities.

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -9,6 +9,7 @@ use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::io::{split, AsyncWriteExt};
 use x25519_dalek::{PublicKey, StaticSecret};
 use rand::rngs::OsRng;
+use zeroize::Zeroize;
 
 use crate::{
     core::{
@@ -172,7 +173,9 @@ pub async fn auto_connect_loop(app: AppHandle) {
         match do_connect_i2p(app.clone()).await {
             Ok(()) => return,
             Err(e) => {
+                #[cfg(debug_assertions)]
                 log::debug!("SAM connect attempt: {}, retrying in 5s", e);
+                let _ = e;
                 tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
             }
         }
@@ -201,10 +204,13 @@ async fn accept_loop(app: AppHandle, session_id: String, sam_addr: String) {
         match accept_once_raw(&session_id, &sam_addr).await {
             Ok((peer_dest, tunnel)) => {
                 if let Err(e) = handle_incoming(&app, peer_dest, tunnel).await {
+                    #[cfg(debug_assertions)]
                     log::warn!("incoming session error: {}", e);
+                    let _ = e;
                 }
             }
             Err(e) => {
+                #[cfg(debug_assertions)]
                 log::warn!("STREAM ACCEPT failed: {}", e);
                 tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
             }
@@ -280,13 +286,14 @@ async fn handle_incoming(
     let ik_a_pub = PublicKey::from(<[u8; 32]>::try_from(ik_a_bytes.as_slice())?);
     let ek_a_pub = PublicKey::from(<[u8; 32]>::try_from(ek_a_bytes.as_slice())?);
 
-    let root_key = {
+    let mut root_key = {
         let id = state.identity.lock().await;
         let keys = id.as_ref().ok_or_else(|| anyhow::anyhow!("no identity"))?;
         x3dh_responder(&keys.ik_secret, &keys.spk_secret, &ik_a_pub, &ek_a_pub)
     };
 
     let ratchet = DoubleRatchet::from_root_key(&root_key, false);
+    root_key.zeroize();
 
     // Send HANDSHAKE_ACK
     let ack = serde_json::to_vec(&HandshakeAck { t: "ack".into() })?;
@@ -356,13 +363,14 @@ pub async fn initiate_session(
     let ek_a = StaticSecret::random_from_rng(OsRng);
     let ek_a_pub = PublicKey::from(&ek_a);
 
-    let root_key = {
+    let mut root_key = {
         let id = state.identity.lock().await;
         let keys = id.as_ref().ok_or("no identity generated")?;
         x3dh_initiator(&keys.ik_secret, &ek_a, &ik_b_pub, &spk_b_pub)
     };
 
     let ratchet = DoubleRatchet::from_root_key(&root_key, true);
+    root_key.zeroize();
 
     // Dial peer
     let tunnel = {
@@ -428,11 +436,15 @@ async fn receive_loop(app: AppHandle, mut reader: tokio::io::ReadHalf<tokio::net
         match read_framed(&mut reader).await {
             Ok(frame) => {
                 if let Err(e) = handle_incoming_message(&app, &frame).await {
+                    #[cfg(debug_assertions)]
                     log::warn!("message handling error: {}", e);
+                    let _ = e;
                 }
             }
             Err(e) => {
+                #[cfg(debug_assertions)]
                 log::info!("peer stream closed: {}", e);
+                let _ = &e;
                 let state = app.state::<AppState>();
                 *state.session.lock().await = None;
                 let _ = app.emit("session_closed", ());
@@ -469,7 +481,7 @@ async fn handle_incoming_message(app: &AppHandle, frame: &[u8]) -> anyhow::Resul
         session.ratchet.decrypt(&ct, wire.n)?
     };
 
-    let content = String::from_utf8(plaintext_buf.as_bytes().to_vec())?;
+    let mut content = String::from_utf8(plaintext_buf.as_bytes().to_vec())?;
     let now = now_secs();
     let expires_at = if settings.ttl_seconds > 0 {
         now + settings.ttl_seconds
@@ -484,6 +496,8 @@ async fn handle_incoming_message(app: &AppHandle, frame: &[u8]) -> anyhow::Resul
         timestamp: now,
         expires_at,
     };
+    // Wipe plaintext intermediate — the content now lives only in SecureBuffer
+    unsafe { content.as_bytes_mut().zeroize(); }
 
     let view = MessageView::from(&entry);
     state.messages.lock().await.push(entry);

--- a/src-tauri/src/core/router.rs
+++ b/src-tauri/src/core/router.rs
@@ -49,6 +49,7 @@ pub async fn start_embedded_router(data_dir: PathBuf) -> Result<u16> {
         .map_err(|e| anyhow::anyhow!("router init failed: {:?}", e))?;
 
     tokio::spawn(router);
+    #[cfg(debug_assertions)]
     log::info!("embedded I2P router started, SAM port: {}", sam_port);
     Ok(sam_port)
 }
@@ -59,14 +60,17 @@ async fn load_or_reseed(data_dir: &PathBuf) -> Vec<Vec<u8>> {
     if let Ok(data) = tokio::fs::read(&cache_path).await {
         let routers = parse_router_cache(&data);
         if routers.len() >= MIN_ROUTERS_CACHED {
+            #[cfg(debug_assertions)]
             log::info!("loaded {} cached I2P routers", routers.len());
             return routers;
         }
     }
 
+    #[cfg(debug_assertions)]
     log::info!("reseeding I2P routers (this may take a moment)...");
     match Reseeder::reseed(None, false).await {
         Ok(routers) => {
+            #[cfg(debug_assertions)]
             log::info!("reseeded {} I2P routers", routers.len());
             let router_bytes: Vec<Vec<u8>> =
                 routers.into_iter().map(|r| r.router_info).collect();
@@ -74,7 +78,9 @@ async fn load_or_reseed(data_dir: &PathBuf) -> Vec<Vec<u8>> {
             router_bytes
         }
         Err(e) => {
+            #[cfg(debug_assertions)]
             log::error!("reseed failed: {:?}", e);
+            let _ = e;
             vec![]
         }
     }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -72,7 +72,9 @@ pub fn run() {
                         commands::session::auto_connect_loop(handle2).await;
                     }
                     Err(e) => {
+                        #[cfg(debug_assertions)]
                         log::error!("failed to start embedded I2P router: {}", e);
+                        let _ = e;
                         set_router_status(&handle2, "error").await;
                     }
                 }


### PR DESCRIPTION
## Security Audit — Hardening Fixes

Full audit of the codebase against the Tasks doc, ARCHITECTURE.md, and implementation. This PR addresses the gaps found.

### Changes

**1. Complete log elimination in release builds**
- All `log::` macro calls (`log::info!`, `log::warn!`, `log::error!`, `log::debug!`) are now wrapped in `#[cfg(debug_assertions)]`
- Previously, while `tauri-plugin-log` was only registered in debug, the `log::` macros still compiled format string literals into the release binary — forensic artifacts for a security-sensitive app
- Now: zero log string literals in release binary

**2. Zeroize X3DH root_key after handshake**
- In both `handle_incoming` (responder) and `initiate_session` (initiator), the `root_key: [u8; 32]` from X3DH was left on the stack after being consumed by `DoubleRatchet::from_root_key`
- Now explicitly `root_key.zeroize()` after use

**3. Zeroize plaintext intermediate in message handling**
- `handle_incoming_message` created a `String` from decrypted plaintext to build a `SecureBuffer` — the original `String` would drop without wiping
- Now the intermediate is zeroized before drop

**4. ARCHITECTURE.md updated to match implementation**
- **CSP**: Was documented as `"csp": null` — now correctly documents the strict CSP that's been in `tauri.conf.json`
- **Safety numbers**: Was documented as "No peer identity pinning" gap — now correctly documents the implemented safety numbers feature
- **Logging**: Updated to describe the full compile-out approach

### Audit Summary — What's Correct

| Area | Status |
|---|---|
| Log file target disabled (stdout only, debug-only) | ✅ Verified + hardened |
| Android lifecycle wipe (onPause/onDestroy) | ✅ Verified |
| Safety numbers (v1) | ✅ Implemented |
| CSP in tauri.conf.json | ✅ Enabled |
| Debug symbols stripped (profile.release strip=true) | ✅ Verified |
| SecureBuffer + mlock + zeroize on drop | ✅ Verified |
| No disk persistence (no SQLite, no message logs) | ✅ Verified |
| Frontend holds no secrets (IPC boundary clean) | ✅ Verified |
| No console.log/println in codebase | ✅ Verified |
| Capabilities minimal (core:default only) | ✅ Verified |
| Sourcemaps disabled in release | ✅ Verified |
| X3DH implementation matches ARCHITECTURE.md | ✅ Verified |
| Symmetric ratchet (KDF chain) correct | ✅ Verified |

### Known Items (v2 / by design)

- **DH ratchet** — symmetric only, documented as v2 task
- **Out-of-order messages** — strict counter enforcement, documented as v2 task
- **`unsafe-inline` in style-src CSP** — required by Tailwind runtime utilities, acceptable tradeoff

---

_This PR was generated with [Oz](https://www.warp.dev/oz)._
