### PR TITLE
fix: strip non-numeric pre-release suffix for Windows MSI build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,17 +51,27 @@ jobs:
 
       # Sync version from git tag (e.g. v1.2.3 -> 1.2.3) so bundle artifacts
       # are named correctly (e.g. ech0_1.2.3_x64-setup.exe).
+      # On Windows the MSI target only accepts numeric pre-release identifiers
+      # (≤ 65535), so non-numeric suffixes like -beta.1 or -rc.2 are stripped.
       - name: Set version from tag
         shell: bash
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+
+          # Strip non-numeric pre-release suffix for Windows MSI compatibility
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            TAURI_VERSION=$(echo "$VERSION" | sed 's/-[^0-9].*//')
+          else
+            TAURI_VERSION="$VERSION"
+          fi
+
           npm pkg set version="$VERSION"
           node -e "
             const fs = require('fs');
             const p = 'src-tauri/tauri.conf.json';
             const cfg = JSON.parse(fs.readFileSync(p, 'utf8'));
-            cfg.version = '$VERSION';
+            cfg.version = '$TAURI_VERSION';
             fs.writeFileSync(p, JSON.stringify(cfg, null, 2) + '\\n');
           "
 


### PR DESCRIPTION
## Problem

The Windows build fails when releasing with a pre-release tag (e.g. `v1.0.0-beta.1`):

```
failed to bundle project `optional pre-release identifier in app version must be numeric-only
and cannot be greater than 65535 for msi target`
```

The MSI installer format requires version pre-release identifiers to be numeric-only and ≤ 65535. Non-numeric suffixes like `-beta.1` or `-rc.2` are not valid.

## Fix

On Windows runners, the "Set version from tag" step now strips non-numeric pre-release suffixes before writing the version to `tauri.conf.json`:

- `1.0.0-beta.1` → `1.0.0` (in `tauri.conf.json` on Windows)
- `1.0.0` → `1.0.0` (unchanged)

The full version string is still preserved in `package.json` and the `VERSION` environment variable for other uses (e.g. release naming).

macOS and Linux builds are unaffected and continue to use the full version.

_This PR was generated with [Oz](https://www.warp.dev/oz)._
