### PR TITLE
fix: app icons, mobile responsiveness, and wipe-on-share

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,6 +184,9 @@ jobs:
       - name: Initialize Tauri Android project
         run: npm run tauri android init
 
+      - name: Generate app icons
+        run: npx tauri icon src-tauri/icons/icon.png
+
       - name: Build Android APK
         run: npm run tauri android build
 

--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src ipc: http://ipc.localhost" />
     <title>ech0</title>
   </head>

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -188,6 +188,9 @@ build() {
         npm run tauri android init
     fi
 
+    log "Generating platform icons from source..."
+    npx tauri icon src-tauri/icons/icon.png
+
     log "Building frontend..."
     npm run build
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -90,6 +90,9 @@ if [[ "$TARGET" == "android" ]]; then
         npm run tauri android init
     fi
 
+    echo "==> Generating platform icons"
+    npx tauri icon src-tauri/icons/icon.png
+
     if [[ "$MODE" == "debug" ]]; then
         echo "==> Building Android APK (debug)"
         npm run tauri android build -- --debug

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -630,3 +630,15 @@ pub async fn get_safety_numbers(state: State<'_, AppState>) -> Result<String, St
         &session.peer_ik_bytes,
     ))
 }
+
+/// Tell the backend to skip the next focus-loss wipe.
+/// The frontend calls this right before copying the session link so the user
+/// can switch to another app to paste without triggering a panic wipe.
+/// The flag is consumed once (single use).
+#[tauri::command]
+pub async fn suppress_wipe(state: State<'_, AppState>) -> Result<(), String> {
+    state
+        .suppress_next_wipe
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,6 +30,7 @@ pub fn run() {
             commands::session::initiate_session,
             commands::session::close_session,
             commands::session::panic_wipe,
+            commands::session::suppress_wipe,
             commands::session::update_settings,
             commands::session::get_settings,
             commands::session::get_router_status,
@@ -104,6 +105,11 @@ pub fn run() {
                     event: tauri::WindowEvent::Focused(false),
                     ..
                 } => {
+                    let state = app_handle.state::<state::AppState>();
+                    // If the frontend signalled a link-share, skip this one wipe.
+                    if state.suppress_next_wipe.swap(false, std::sync::atomic::Ordering::Relaxed) {
+                        return;
+                    }
                     let app = app_handle.clone();
                     tauri::async_runtime::spawn(async move {
                         commands::session::do_panic_wipe(app).await;

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::sync::atomic::AtomicBool;
 use tokio::{
     io::WriteHalf,
     net::TcpStream,
@@ -81,6 +82,11 @@ pub struct AppState {
     pub router_sam_port: Mutex<Option<u16>>,
     /// Last known router status — queried by frontend on mount to avoid event race on release.
     pub router_status: Mutex<String>,
+    /// When `true`, the next focus-loss event on Android will NOT trigger a
+    /// panic wipe. The flag is consumed (reset to `false`) after one use.
+    /// This allows the user to copy a session link and switch apps to share it
+    /// without the app wiping itself.
+    pub suppress_next_wipe: AtomicBool,
 }
 
 impl Default for AppState {
@@ -93,6 +99,7 @@ impl Default for AppState {
             i2p: Mutex::new(None),
             router_sam_port: Mutex::new(None),
             router_status: Mutex::new("idle".to_string()),
+            suppress_next_wipe: AtomicBool::new(false),
         }
     }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,11 +29,12 @@
     "active": true,
     "targets": "all",
     "icon": [
-      "icons/icon-32x32.png",
-      "icons/icon-128x128.png",
-      "icons/icon-256x256.png",
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
       "icons/icon.icns",
-      "icons/icon.ico"
+      "icons/icon.ico",
+      "icons/icon.png"
     ]
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,7 +110,7 @@ export default function App() {
 
   return (
     <StoreContext.Provider value={{ state, dispatch }}>
-      <div className="h-full flex flex-col bg-black relative overflow-hidden">
+      <div className="h-full flex flex-col bg-black relative overflow-hidden safe-top safe-bottom">
         <Header
           onSettingsToggle={() => setShowSettings((v) => !v)}
           onWipeRequest={() => setShowWipeConfirm(true)}

--- a/src/components/SessionSetup.tsx
+++ b/src/components/SessionSetup.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { useStore } from "../store/sessionStore";
 
 interface SessionSetupProps {
@@ -21,6 +22,9 @@ export default function SessionSetup({ onInitiateSession }: SessionSetupProps) {
   const handleCopy = async () => {
     if (!connectLink) return;
     try {
+      // Suppress the Android wipe-on-focus-loss so the user can switch
+      // to another app to paste the link without triggering a panic wipe.
+      await invoke("suppress_wipe").catch(() => undefined);
       await navigator.clipboard.writeText(connectLink);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);

--- a/src/index.css
+++ b/src/index.css
@@ -26,6 +26,18 @@ html, body, #root {
   user-select: none;
 }
 
+/* Safe area insets for mobile (status bar + navigation bar) */
+.safe-top {
+  padding-top: env(safe-area-inset-top);
+}
+.safe-bottom {
+  padding-bottom: env(safe-area-inset-bottom);
+}
+.safe-x {
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+}
+
 /* Custom scrollbar */
 ::-webkit-scrollbar { width: 4px; }
 ::-webkit-scrollbar-track { background: transparent; }


### PR DESCRIPTION
## Summary

Fixes three issues: app icons showing the default Tauri icon, mobile responsiveness (status bar / bottom nav overlap), and the wipe-on-focus-loss preventing link sharing on Android.

## Changes

### 1. App icons — use standard Tauri 2 naming
`bundle.icon` in `tauri.conf.json` was referencing `icon-32x32.png`, `icon-128x128.png`, `icon-256x256.png` — non-standard names that some platforms ignore in favour of the default Tauri icon.

Updated to the standard Tauri 2 convention: `32x32.png`, `128x128.png`, `128x128@2x.png`, `icon.png`, `icon.icns`, `icon.ico`.

### 2. Mobile icon generation
Added `npx tauri icon src-tauri/icons/icon.png` step after `tauri android init` in:
- `scripts/build-android.sh`
- `scripts/build.sh`
- `.github/workflows/release.yml`

This regenerates all mipmap icons from the custom source so Android builds use the ech0 icon instead of the default.

### 3. Mobile responsiveness (safe area insets)
- Added `viewport-fit=cover` to the HTML `<meta name="viewport">` tag
- Added CSS utility classes (`safe-top`, `safe-bottom`, `safe-x`) using `env(safe-area-inset-*)` 
- Applied `safe-top safe-bottom` to the root app container

This prevents the status bar and bottom navigation controls from overlapping the app content.

### 4. Suppress wipe when sharing link
On Android, the app wipes on focus loss (`Focused(false)`). This made it impossible to copy a session link and switch to another app to share it.

- Added `suppress_next_wipe: AtomicBool` to `AppState`
- Added `suppress_wipe` Tauri command (single-use flag)
- Frontend calls `suppress_wipe` before `clipboard.writeText()` in `SessionSetup`
- The `Focused(false)` handler consumes and resets the flag, skipping one wipe

The flag is atomic and consumed immediately — subsequent focus-loss events wipe normally.

---

_This PR was generated with [Oz](https://www.warp.dev/oz)._
