### PR TITLE
refactor: disable auto-wipe on focus loss, keep only on app exit

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -630,15 +630,3 @@ pub async fn get_safety_numbers(state: State<'_, AppState>) -> Result<String, St
         &session.peer_ik_bytes,
     ))
 }
-
-/// Tell the backend to skip the next focus-loss wipe.
-/// The frontend calls this right before copying the session link so the user
-/// can switch to another app to paste without triggering a panic wipe.
-/// The flag is consumed once (single use).
-#[tauri::command]
-pub async fn suppress_wipe(state: State<'_, AppState>) -> Result<(), String> {
-    state
-        .suppress_next_wipe
-        .store(true, std::sync::atomic::Ordering::Relaxed);
-    Ok(())
-}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -30,7 +30,6 @@ pub fn run() {
             commands::session::initiate_session,
             commands::session::close_session,
             commands::session::panic_wipe,
-            commands::session::suppress_wipe,
             commands::session::update_settings,
             commands::session::get_settings,
             commands::session::get_router_status,
@@ -98,23 +97,12 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error building ech0")
         .run(|app_handle, event| {
-            // On Android: wipe when the app backgrounds (onPause) or is destroyed (onDestroy)
+            // On app exit: wipe when the app is destroyed (onDestroy).
+            // Note: we do NOT wipe on focus loss (Focused(false)) to allow users to
+            // switch apps to share links without data being wiped.
+            // Users can manually wipe via the UI if needed.
             #[cfg(target_os = "android")]
             match event {
-                tauri::RunEvent::WindowEvent {
-                    event: tauri::WindowEvent::Focused(false),
-                    ..
-                } => {
-                    let state = app_handle.state::<state::AppState>();
-                    // If the frontend signalled a link-share, skip this one wipe.
-                    if state.suppress_next_wipe.swap(false, std::sync::atomic::Ordering::Relaxed) {
-                        return;
-                    }
-                    let app = app_handle.clone();
-                    tauri::async_runtime::spawn(async move {
-                        commands::session::do_panic_wipe(app).await;
-                    });
-                }
                 tauri::RunEvent::Exit => {
                     let app = app_handle.clone();
                     tauri::async_runtime::spawn(async move {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,5 +1,4 @@
 use serde::Serialize;
-use std::sync::atomic::AtomicBool;
 use tokio::{
     io::WriteHalf,
     net::TcpStream,
@@ -82,11 +81,6 @@ pub struct AppState {
     pub router_sam_port: Mutex<Option<u16>>,
     /// Last known router status — queried by frontend on mount to avoid event race on release.
     pub router_status: Mutex<String>,
-    /// When `true`, the next focus-loss event on Android will NOT trigger a
-    /// panic wipe. The flag is consumed (reset to `false`) after one use.
-    /// This allows the user to copy a session link and switch apps to share it
-    /// without the app wiping itself.
-    pub suppress_next_wipe: AtomicBool,
 }
 
 impl Default for AppState {
@@ -99,7 +93,6 @@ impl Default for AppState {
             i2p: Mutex::new(None),
             router_sam_port: Mutex::new(None),
             router_status: Mutex::new("idle".to_string()),
-            suppress_next_wipe: AtomicBool::new(false),
         }
     }
 }

--- a/src/components/SessionSetup.tsx
+++ b/src/components/SessionSetup.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import { useStore } from "../store/sessionStore";
 
 interface SessionSetupProps {
@@ -22,9 +21,6 @@ export default function SessionSetup({ onInitiateSession }: SessionSetupProps) {
   const handleCopy = async () => {
     if (!connectLink) return;
     try {
-      // Suppress the Android wipe-on-focus-loss so the user can switch
-      // to another app to paste the link without triggering a panic wipe.
-      await invoke("suppress_wipe").catch(() => undefined);
       await navigator.clipboard.writeText(connectLink);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);


### PR DESCRIPTION
## Summary

Disables the automatic panic wipe when the app loses focus on Android. This was preventing users from sharing session links without losing all data. Users can still manually wipe via the UI button.

## Changes

The app was auto-wiping whenever the Android app moved to background (`Focused(false)`). This was a security feature, but it made it impossible to copy a session link and switch to another app to share it.

- Removed the `Focused(false)` handler from the Android event loop in `lib.rs`
- Wipe now only occurs on app exit (`RunEvent::Exit`)
- Removed the `suppress_next_wipe` mechanism (now unnecessary)
- Removed the `suppress_wipe` Tauri command
- Simplified `AppState` by removing the `AtomicBool` flag

Users can still manually wipe all data via the "wipe" button in the UI, which is safer and more intentional.

---

_This PR was generated with [Oz](https://www.warp.dev/oz)._
