### PR TITLE
fix: send session_end notification before wipe/close (#6)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -41,6 +41,11 @@ struct HandshakeAck {
     t: String,
 }
 
+#[derive(Serialize, Deserialize)]
+struct SessionEnd {
+    t: String,
+}
+
 #[derive(Serialize)]
 pub struct IdentityInfo {
     pub b32_addr: String,
@@ -436,9 +441,13 @@ async fn receive_loop(app: AppHandle, mut reader: tokio::io::ReadHalf<tokio::net
         match read_framed(&mut reader).await {
             Ok(frame) => {
                 if let Err(e) = handle_incoming_message(&app, &frame).await {
+                    let err_msg = e.to_string();
                     #[cfg(debug_assertions)]
-                    log::warn!("message handling error: {}", e);
-                    let _ = e;
+                    log::warn!("message handling error: {}", err_msg);
+                    // If the peer ended the session, stop the receive loop
+                    if err_msg.contains("peer ended session") {
+                        break;
+                    }
                 }
             }
             Err(e) => {
@@ -462,7 +471,24 @@ struct WireMessage {
     n: u32,
 }
 
+/// Generic wire envelope used to inspect the `t` field before full deserialization.
+#[derive(Deserialize)]
+struct WireEnvelope {
+    t: String,
+}
+
 async fn handle_incoming_message(app: &AppHandle, frame: &[u8]) -> anyhow::Result<()> {
+    // Peek at the type field to handle control messages before attempting full parse
+    let envelope: WireEnvelope = serde_json::from_slice(frame)?;
+
+    // Handle session_end: peer is closing/wiping their session
+    if envelope.t == "end" {
+        let state = app.state::<AppState>();
+        *state.session.lock().await = None;
+        let _ = app.emit("session_closed", serde_json::json!({ "reason": "peer_ended" }));
+        return Err(anyhow::anyhow!("peer ended session"));
+    }
+
     let wire: WireMessage = serde_json::from_slice(frame)?;
     if wire.t != "msg" {
         return Ok(());
@@ -511,7 +537,9 @@ async fn handle_incoming_message(app: &AppHandle, frame: &[u8]) -> anyhow::Resul
 pub async fn close_session(state: State<'_, AppState>) -> Result<(), String> {
     let mut sess = state.session.lock().await;
     if let Some(mut s) = sess.take() {
-        // Shut down write half to signal peer
+        // Notify peer that we are ending the session before shutting down
+        let end_msg = serde_json::to_vec(&SessionEnd { t: "end".into() }).unwrap_or_default();
+        let _ = write_framed(&mut s.stream_writer, &end_msg).await;
         let _ = s.stream_writer.shutdown().await;
     }
     state.messages.lock().await.clear();
@@ -529,6 +557,9 @@ pub async fn do_panic_wipe(app: AppHandle) {
     {
         let mut sess = state.session.lock().await;
         if let Some(mut s) = sess.take() {
+            // Notify peer that session is ending before destroying everything
+            let end_msg = serde_json::to_vec(&SessionEnd { t: "end".into() }).unwrap_or_default();
+            let _ = write_framed(&mut s.stream_writer, &end_msg).await;
             let _ = s.stream_writer.shutdown().await;
         }
     }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -439,17 +439,15 @@ pub async fn initiate_session(
 async fn receive_loop(app: AppHandle, mut reader: tokio::io::ReadHalf<tokio::net::TcpStream>) {
     loop {
         match read_framed(&mut reader).await {
-            Ok(frame) => {
-                if let Err(e) = handle_incoming_message(&app, &frame).await {
-                    let err_msg = e.to_string();
+            Ok(frame) => match handle_incoming_message(&app, &frame).await {
+                Ok(true) => {}
+                Ok(false) => break,
+                Err(e) => {
                     #[cfg(debug_assertions)]
-                    log::warn!("message handling error: {}", err_msg);
-                    // If the peer ended the session, stop the receive loop
-                    if err_msg.contains("peer ended session") {
-                        break;
-                    }
+                    log::warn!("message handling error: {}", e);
+                    let _ = e;
                 }
-            }
+            },
             Err(e) => {
                 #[cfg(debug_assertions)]
                 log::info!("peer stream closed: {}", e);
@@ -477,7 +475,7 @@ struct WireEnvelope {
     t: String,
 }
 
-async fn handle_incoming_message(app: &AppHandle, frame: &[u8]) -> anyhow::Result<()> {
+async fn handle_incoming_message(app: &AppHandle, frame: &[u8]) -> anyhow::Result<bool> {
     // Peek at the type field to handle control messages before attempting full parse
     let envelope: WireEnvelope = serde_json::from_slice(frame)?;
 
@@ -486,12 +484,12 @@ async fn handle_incoming_message(app: &AppHandle, frame: &[u8]) -> anyhow::Resul
         let state = app.state::<AppState>();
         *state.session.lock().await = None;
         let _ = app.emit("session_closed", serde_json::json!({ "reason": "peer_ended" }));
-        return Err(anyhow::anyhow!("peer ended session"));
+        return Ok(false);
     }
 
     let wire: WireMessage = serde_json::from_slice(frame)?;
     if wire.t != "msg" {
-        return Ok(());
+        return Ok(true);
     }
 
     let ct = B64
@@ -529,7 +527,7 @@ async fn handle_incoming_message(app: &AppHandle, frame: &[u8]) -> anyhow::Resul
     state.messages.lock().await.push(entry);
     let _ = app.emit("message_received", view);
 
-    Ok(())
+    Ok(true)
 }
 
 /// Close the active session, zeroizing all session key material.


### PR DESCRIPTION
## Fix: Send session_end notification before wipe/close

Closes #6

### Problem
When a user triggers `panic_wipe()` or `close_session()`, the local session is shut down but the peer receives no protocol-level notification. This creates an asymmetric state where one side thinks the session is active while the other has already destroyed it.

### Solution
- Added a new `"end"` wire message type to the protocol
- Both `close_session` and `do_panic_wipe` now send a `{"t":"end"}` frame to the peer **before** shutting down the stream writer
- The `receive_loop` / `handle_incoming_message` now recognizes `"end"` messages and:
  - Clears the local session
  - Emits `session_closed` with `reason: "peer_ended"` to the frontend
  - Breaks the receive loop cleanly

### Security considerations
- The `"end"` message is sent as a best-effort signal — if the I2P tunnel is already broken, the send may fail silently, which is acceptable since the stream will eventually error out on the peer side
- No sensitive data is included in the `"end"` frame

_This PR was generated with [Oz](https://www.warp.dev/oz)._
