### PR TITLE
fix: send explicit protocol error on session race condition (#8)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -41,6 +41,14 @@ struct HandshakeAck {
     t: String,
 }
 
+/// Protocol error sent when a handshake is rejected (e.g. session already active).
+#[derive(Serialize, Deserialize)]
+struct ProtocolError {
+    t: String,
+    code: String,
+    msg: String,
+}
+
 #[derive(Serialize)]
 pub struct IdentityInfo {
     pub b32_addr: String,
@@ -263,8 +271,17 @@ async fn handle_incoming(
 ) -> anyhow::Result<()> {
     let state = app.state::<AppState>();
 
-    // Reject if session already active
+    // Reject if session already active — send explicit error to initiator
     if state.session.lock().await.is_some() {
+        let (_, mut writer) = split(tunnel);
+        let err_frame = serde_json::to_vec(&ProtocolError {
+            t: "err".into(),
+            code: "session_active".into(),
+            msg: "peer already has an active session".into(),
+        })
+        .unwrap_or_default();
+        let _ = write_framed(&mut writer, &err_frame).await;
+        log::info!("rejected incoming connection from {}: session already active", peer_dest);
         return Ok(());
     }
 
@@ -401,10 +418,22 @@ pub async fn initiate_session(
         .await
         .map_err(|e| e.to_string())?;
 
-    // Wait for ACK
+    // Wait for ACK (or protocol error)
     let ack_frame = read_framed(&mut reader)
         .await
         .map_err(|e| e.to_string())?;
+
+    // Check if peer sent a protocol error instead of an ACK
+    if let Ok(err) = serde_json::from_slice::<ProtocolError>(&ack_frame) {
+        if err.t == "err" {
+            let user_msg = match err.code.as_str() {
+                "session_active" => "Peer already has an active session".to_string(),
+                _ => format!("Peer rejected connection: {}", err.msg),
+            };
+            return Err(user_msg);
+        }
+    }
+
     let ack: HandshakeAck = serde_json::from_slice(&ack_frame).map_err(|e| e.to_string())?;
     if ack.t != "ack" {
         return Err(format!("unexpected ack type: {}", ack.t));

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -271,6 +271,22 @@ async fn handle_incoming(
 ) -> anyhow::Result<()> {
     let state = app.state::<AppState>();
 
+    let session_gate = match state.session_gate.try_lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            let (_, mut writer) = split(tunnel);
+            let err_frame = serde_json::to_vec(&ProtocolError {
+                t: "err".into(),
+                code: "session_busy".into(),
+                msg: "peer is already establishing a session".into(),
+            })
+            .unwrap_or_default();
+            let _ = write_framed(&mut writer, &err_frame).await;
+            log::info!("rejected incoming connection from {}: session establishment busy", peer_dest);
+            return Ok(());
+        }
+    };
+
     // Reject if session already active — send explicit error to initiator
     if state.session.lock().await.is_some() {
         let (_, mut writer) = split(tunnel);
@@ -335,6 +351,7 @@ async fn handle_incoming(
         receive_loop(app_clone, reader).await;
     });
 
+    drop(session_gate);
     Ok(())
 }
 
@@ -371,6 +388,14 @@ pub async fn initiate_session(
     let spk_b_bytes = hex::decode(&peer.s).map_err(|e| e.to_string())?;
     if ik_b_bytes.len() != 32 || spk_b_bytes.len() != 32 {
         return Err("invalid key lengths in peer info".into());
+    }
+
+    let session_gate = state
+        .session_gate
+        .try_lock()
+        .map_err(|_| "session establishment already in progress".to_string())?;
+    if state.session.lock().await.is_some() {
+        return Err("session already active".into());
     }
 
     let ik_b_pub = PublicKey::from(<[u8; 32]>::try_from(ik_b_bytes.as_slice()).unwrap());
@@ -456,6 +481,7 @@ pub async fn initiate_session(
         receive_loop(app_clone, reader).await;
     });
 
+    drop(session_gate);
     Ok(())
 }
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -74,6 +74,7 @@ impl Default for AppSettings {
 pub struct AppState {
     pub identity: Mutex<Option<IdentityKeys>>,
     pub session: Mutex<Option<ActiveSession>>,
+    pub session_gate: Mutex<()>,
     pub messages: Mutex<Vec<MessageEntry>>,
     pub settings: Mutex<AppSettings>,
     pub i2p: Mutex<Option<I2pSession>>,
@@ -88,6 +89,7 @@ impl Default for AppState {
         Self {
             identity: Mutex::new(None),
             session: Mutex::new(None),
+            session_gate: Mutex::new(()),
             messages: Mutex::new(Vec::new()),
             settings: Mutex::new(AppSettings::default()),
             i2p: Mutex::new(None),


### PR DESCRIPTION
## Fix: Send explicit protocol error on session race condition

Closes #8

### Problem
When a peer tried to connect to a node that already had an active session, `handle_incoming` silently returned `Ok(())` without sending any response. The initiator would hang indefinitely waiting for a handshake ACK that never came.

### Solution
- Added `ProtocolError` wire type (`{t: "err", code: "...", msg: "..."}`)
- When a session is already active, `handle_incoming` now sends an error frame with `code: "session_active"` before closing the connection
- The initiator (`initiate_session`) now checks for protocol errors in the response frame before attempting to parse it as a handshake ACK
- Maps error codes to user-friendly messages (e.g., "Peer already has an active session")

### Security considerations
- The error frame reveals minimal information (only that a session is active, not any identity details)
- No key material is exchanged in the error path

_This PR was generated with [Oz](https://www.warp.dev/oz)._
