### PR TITLE
fix: add idempotency to prevent duplicate messages on network redelivery (#10)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -468,11 +468,24 @@ async fn handle_incoming_message(app: &AppHandle, frame: &[u8]) -> anyhow::Resul
         return Ok(());
     }
 
+    let state = app.state::<AppState>();
+    
+    // Check for duplicate message to provide idempotency on network redelivery
+    let mut received_ids = state.received_message_ids.lock().await;
+    if received_ids.contains(&wire.id) {
+        // Duplicate message - skip silently
+        #[cfg(debug_assertions)]
+        log::debug!("duplicate message ignored: {}", wire.id);
+        drop(received_ids);
+        return Ok(());
+    }
+    received_ids.insert(wire.id.clone());
+    drop(received_ids);
+
     let ct = B64
         .decode(&wire.ct)
         .map_err(|e| anyhow::anyhow!("base64 decode: {}", e))?;
 
-    let state = app.state::<AppState>();
     let settings = state.settings.lock().await.clone();
 
     let plaintext_buf = {
@@ -515,6 +528,8 @@ pub async fn close_session(state: State<'_, AppState>) -> Result<(), String> {
         let _ = s.stream_writer.shutdown().await;
     }
     state.messages.lock().await.clear();
+    // Clear message ID tracking so new session can receive same IDs
+    state.received_message_ids.lock().await.clear();
     Ok(())
 }
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -447,6 +447,7 @@ async fn receive_loop(app: AppHandle, mut reader: tokio::io::ReadHalf<tokio::net
                 let _ = &e;
                 let state = app.state::<AppState>();
                 *state.session.lock().await = None;
+                state.received_message_ids.lock().await.clear();
                 let _ = app.emit("session_closed", ());
                 break;
             }
@@ -471,7 +472,7 @@ async fn handle_incoming_message(app: &AppHandle, frame: &[u8]) -> anyhow::Resul
     let state = app.state::<AppState>();
     
     // Check for duplicate message to provide idempotency on network redelivery
-    let mut received_ids = state.received_message_ids.lock().await;
+    let received_ids = state.received_message_ids.lock().await;
     if received_ids.contains(&wire.id) {
         // Duplicate message - skip silently
         #[cfg(debug_assertions)]
@@ -479,7 +480,6 @@ async fn handle_incoming_message(app: &AppHandle, frame: &[u8]) -> anyhow::Resul
         drop(received_ids);
         return Ok(());
     }
-    received_ids.insert(wire.id.clone());
     drop(received_ids);
 
     let ct = B64
@@ -514,6 +514,7 @@ async fn handle_incoming_message(app: &AppHandle, frame: &[u8]) -> anyhow::Resul
 
     let view = MessageView::from(&entry);
     state.messages.lock().await.push(entry);
+    state.received_message_ids.lock().await.insert(wire.id);
     let _ = app.emit("message_received", view);
 
     Ok(())
@@ -548,6 +549,7 @@ pub async fn do_panic_wipe(app: AppHandle) {
         }
     }
     state.messages.lock().await.clear();
+    state.received_message_ids.lock().await.clear();
     *state.identity.lock().await = None;
     *state.i2p.lock().await = None;
 

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::collections::HashSet;
 use tokio::{
     io::WriteHalf,
     net::TcpStream,
@@ -81,6 +82,8 @@ pub struct AppState {
     pub router_sam_port: Mutex<Option<u16>>,
     /// Last known router status — queried by frontend on mount to avoid event race on release.
     pub router_status: Mutex<String>,
+    /// Track message IDs we've already received to provide idempotency on network redelivery.
+    pub received_message_ids: Mutex<HashSet<String>>,
 }
 
 impl Default for AppState {
@@ -93,6 +96,7 @@ impl Default for AppState {
             i2p: Mutex::new(None),
             router_sam_port: Mutex::new(None),
             router_status: Mutex::new("idle".to_string()),
+            received_message_ids: Mutex::new(HashSet::new()),
         }
     }
 }


### PR DESCRIPTION
## Fix: Add idempotency to prevent duplicate messages on network redelivery

Closes #10

### Problem
When I2P network conditions cause redelivery of the same message (a documented behavior of I2P's unreliable delivery semantics), the same message appears multiple times in the chat interface. This creates:

1. **User confusion**: Users see the same message repeated
2. **Message clutter**: Chat history becomes unreadable with duplicates
3. **No detection mechanism**: The application has no way to know if a message was already received

This is particularly problematic on unstable I2P connections during router bootstrapping or when tunnels degrade.

### Solution

**Implement message ID tracking for idempotency:**

1. **HashSet tracking**:
   - Added `received_message_ids: Mutex<HashSet<String>>` to `AppState`
   - Tracks all message IDs that have been successfully processed
   - Uses HashSet for O(1) lookup performance

2. **Duplicate detection in `handle_incoming_message`**:
   - Before processing, check if message ID already exists in the set
   - If duplicate: skip silently (with debug logging)
   - If new: insert into set and process normally

3. **Cleanup on session close**:
   - When `close_session` is called, clear the `received_message_ids` set
   - Allows the same IDs to be used in new sessions
   - Prevents unbounded growth of the set across sessions

### Security considerations

- Message IDs are UUIDs or similar unique identifiers (not sensitive)
- Tracking is in-memory only (never persisted to disk)
- Cleared on session close to prevent memory leaks

### Implementation details

- Uses `std::collections::HashSet` for efficient duplicate detection
- Mutex protects concurrent access from receive loop and session close
- Duplicate messages are silently skipped (logged in debug builds for troubleshooting)
- Message ID tracking is scoped to the current session lifecycle